### PR TITLE
fix: remove backslash escape to fix f-e-d-c updater pattern

### DIFF
--- a/gg.norisk.NoRiskClientLauncherV3.yml
+++ b/gg.norisk.NoRiskClientLauncherV3.yml
@@ -43,7 +43,7 @@ modules:
         tag: v0.6.11
         x-checker-data:
           type: git
-          tag-pattern: ^v([\\d.]+)$
+          tag-pattern: ^v([\d.]+)$
           version-scheme: semantic
           is-main-source: true
       - cargo-sources.json


### PR DESCRIPTION
This pull request includes a minor update to the `gg.norisk.NoRiskClientLauncherV3.yml` configuration file. The change corrects the regular expression used for matching version tags in the `tag-pattern` field.