### PR TITLE
fix: add pull-requests and issues write permission for update workflow

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -2,6 +2,8 @@ name: Check for updates
 
 permissions:
   contents: write
+  pull-requests: write
+  issues: write
 
 on:
   schedule: # for scheduling to work this file must be in the default branch


### PR DESCRIPTION
This pull request makes a small update to the workflow permissions in `.github/workflows/update.yml` to allow the workflow to write to pull requests and issues in addition to contents.