### PR TITLE
Add beta version checking to f-e-d-c and fix dependency manifest generation

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -45,7 +45,7 @@ jobs:
           path: noriskclient-launcher
           ref: ${{ steps.get-tag.outputs.latest_tag }}
 
-      - name: Checkout this repository
+      - name: Checkout this repository (flathub branch)
         uses: actions/checkout@v4
         with:
           path: flathub
@@ -88,7 +88,7 @@ jobs:
             flatpak-node-generator yarn noriskclient-launcher/yarn.lock -o flathub/node-sources.json
           fi
 
-      - name: Commit changes
+      - name: Commit generated dependency manifests (local commit only)
         run: |
           cd flathub
           git config user.name "github-actions[bot]"
@@ -107,26 +107,14 @@ jobs:
 
           if [ -n "$FILES_TO_COMMIT" ] && [[ $(git status --porcelain $FILES_TO_COMMIT) ]]; then
             git add -- $FILES_TO_COMMIT
-            git commit -m "chore: update flatpak dependency manifests for launcher ${LAUNCHER_VERSION}"
-            git push origin HEAD:${{ matrix.branch }}
+            git commit -m "chore: update flatpak dependency manifests for launcher ${LAUNCHER_VERSION} (branch: ${{ matrix.branch }})"
+            echo "Committed dependency manifest updates locally. These commits will be included in the update PR."
           else
             echo "No changes to commit."
           fi
-  flatpak-external-data-checker:
-    runs-on: ubuntu-latest
 
-    needs: update-sources
-
-    strategy:
-      matrix:
-        branch: [master, beta] # list all branches to check
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ matrix.branch }}
-
-      - uses: docker://ghcr.io/flathub/flatpak-external-data-checker:latest
+      - name: Run flatpak external data checker (create/update PR branch including the local commits)
+        uses: docker://ghcr.io/flathub/flatpak-external-data-checker:latest
         env:
           GIT_AUTHOR_NAME: Flatpak External Data Checker
           GIT_COMMITTER_NAME: Flatpak External Data Checker
@@ -135,4 +123,6 @@ jobs:
           GIT_COMMITTER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          args: --update --commit-only --never-fork gg.norisk.NoRiskClientLauncherV3.yml
+          # Use --update so the checker will commit its changes, create the branch in-repo and open the PR.
+          # Pass the manifest path relative to the repository root (the flathub manifests live under flathub/).
+          args: --update --never-fork flathub/gg.norisk.NoRiskClientLauncherV3.yml


### PR DESCRIPTION
This pull request updates the GitHub workflow in `.github/workflows/update.yml` to support both `master` and `beta` branches, improve release selection logic, and streamline dependency manifest updates and PR creation. The changes ensure the workflow correctly handles stable and prerelease tags, commits dependency updates locally, and passes the correct manifest path to the external data checker.

**Branch and release selection improvements:**

* The workflow now runs for both `master` and `beta` branches, selecting the latest stable release for `master` and the latest prerelease for `beta`. If no suitable tag is found, the job exits gracefully without error.

**Repository checkout and commit logic:**

* The workflow checks out the corresponding branch for the flathub repository, ensuring updates are applied to the correct branch.
* Dependency manifest updates are committed locally with a branch-specific commit message, but are not pushed directly; these commits will be included in the update PR. [[1]](diffhunk://#diff-571e661e1640e6f1f415c087c9a72af346ea9fd4655ff5545e5ad6ea596bab97L77-R91) [[2]](diffhunk://#diff-571e661e1640e6f1f415c087c9a72af346ea9fd4655ff5545e5ad6ea596bab97L96-R117)

**External data checker invocation:**

* The flatpak external data checker step now uses the updated manifest path (`flathub/gg.norisk.NoRiskClientLauncherV3.yml`) and ensures branch creation and PR opening occur in-repo.