### PR TITLE
fix: add parentheses around beta tag pattern to add a capture group

### DIFF
--- a/gg.norisk.NoRiskClientLauncherV3.yml
+++ b/gg.norisk.NoRiskClientLauncherV3.yml
@@ -43,7 +43,7 @@ modules:
         tag: v0.6.12-beta.1
         x-checker-data:
           type: git
-          tag-pattern: ^v\d+\.\d+\.\d+-beta\.\d+$
+          tag-pattern: ^v(\d+\.\d+\.\d+-beta\.\d+)$
           version-scheme: semantic
           is-main-source: true
         commit: bf90c25d45b92dc22bcfb0f381ed6aac93735240


### PR DESCRIPTION
This pull request makes a minor update to the regular expression used for the `tag-pattern` in the `gg.norisk.NoRiskClientLauncherV3.yml` file to improve version tag matching.

* Configuration update:
  * Changed the `tag-pattern` regex to use a capturing group for the version number, making the pattern more precise for matching tags like `vX.Y.Z-beta.N`. (`gg.norisk.NoRiskClientLauncherV3.yml`)