### PR TITLE
Drop libusb

### DIFF
--- a/gg.norisk.NoRiskClientLauncherV3.yml
+++ b/gg.norisk.NoRiskClientLauncherV3.yml
@@ -21,8 +21,8 @@ finish-args:
   - --filesystem=xdg-download:ro
 
 modules:
-    # Might be needed by some Controller mods (see https://github.com/isXander/Controlify/issues/31)
-  - shared-modules/libusb/libusb.json
+    # libusb might be needed by some Controller mods (see https://github.com/isXander/Controlify/issues/31)
+    # Indeed, it is already provided by the runtime
 
   - shared-modules/libappindicator/libappindicator-gtk3-12.10.json
   - name: flite


### PR DESCRIPTION
Remove libusb since it's included in the runtime version 49

Fixes: https://github.com/flathub/gg.norisk.NoRiskClientLauncherV3/issues/71